### PR TITLE
Add prometheus PodMonitor to mt-ingress local-setup

### DIFF
--- a/config/local-setup/workloads/mt-ingress.yaml
+++ b/config/local-setup/workloads/mt-ingress.yaml
@@ -65,6 +65,24 @@ spec:
   type: LoadBalancer
 
 ---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mt-ingress
+spec:
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /stats/prometheus
+      port: admin
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: envoy-deployment
+      app.kubernetes.io/instance: mt-ingress
+      app.kubernetes.io/managed-by: marin3r-operator
+      app.kubernetes.io/name: marin3r
+
+---
 apiVersion: marin3r.3scale.net/v1alpha1
 kind: EnvoyConfig
 metadata:

--- a/config/local-setup/workloads/mt-ingress.yaml
+++ b/config/local-setup/workloads/mt-ingress.yaml
@@ -71,7 +71,7 @@ metadata:
   name: mt-ingress
 spec:
   podMetricsEndpoints:
-    - interval: 30s
+    - interval: 60s
       path: /stats/prometheus
       port: admin
       scheme: http


### PR DESCRIPTION
While working on https://github.com/3scale-sre/platform/issues/1598

I saw that mt-ingress did not have monitoring enabled, so I added the required PodMonitor.

/kind feature
/priority important-soon
/assign