### PR TITLE
Feat/local-setup envoy improvements

### DIFF
--- a/config/local-setup/workloads/apicast.yaml
+++ b/config/local-setup/workloads/apicast.yaml
@@ -44,7 +44,7 @@ spec:
       endpoints:
         - marin3rSidecar:
             dynamicConfigs:
-              gateway_cluster:
+              gateway_cluster_production:
                 cluster:
                   host: 127.0.0.1
                   isHttp2: false
@@ -78,7 +78,7 @@ spec:
                         - match:
                             prefix: /
                           route:
-                            cluster: gateway_cluster
+                            cluster: gateway_cluster_production
                             timeout: 30s
             elasticLoadBalancerConfig:
               proxyProtocol: false
@@ -125,7 +125,7 @@ spec:
           strategy: Marin3rSidecar
           marin3rSidecar:
             dynamicConfigs:
-              gateway_cluster:
+              gateway_cluster_staging:
                 cluster:
                   host: 127.0.0.1
                   isHttp2: false
@@ -165,7 +165,7 @@ spec:
                         - match:
                             prefix: /
                           route:
-                            cluster: gateway_cluster
+                            cluster: gateway_cluster_staging
                             timeout: 30s
             elasticLoadBalancerConfig:
               proxyProtocol: false

--- a/config/local-setup/workloads/mt-ingress.yaml
+++ b/config/local-setup/workloads/mt-ingress.yaml
@@ -224,3 +224,15 @@ spec:
                 route:
                   cluster: system_app
                   timeout: 120s
+                  retry_policy:
+                    retry_on: connect-failure,reset,refused-stream,unavailable,cancelled,retriable-status-codes
+                    retriable_status_codes:
+                    - 503
+                    num_retries: 10
+                    retry_back_off:
+                      base_interval: 1s
+                    retry_host_predicate:
+                    - name: envoy.retry_host_predicates.previous_hosts
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+                    host_selection_retry_max_attempts: 5


### PR DESCRIPTION
Related to https://github.com/3scale-sre/platform/issues/1598
- Rename apicast gateway cluster name to include the environment, so that way you can filter its metrics on marin3r envoy dashboard
- Add the same retry policy we have in production for mt-ingress local-setup, that mitigate the connection reset that affects main system admin dashboard. The reset occurs because this dashboard loads to much data, dev environment is cold (not cache, low resources..) and system-app has its own timeout


/kind feature
/priority important-soon
/assign