### PR TITLE
Add mysql max-connections to system-mysql local-setup database

### DIFF
--- a/config/local-setup/databases/system-mysql/resources.yaml
+++ b/config/local-setup/databases/system-mysql/resources.yaml
@@ -21,6 +21,7 @@ spec:
             - mysqld
             - --default-authentication-plugin=mysql_native_password
             - --disable-log-bin
+            - --max_connections=300
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:


### PR DESCRIPTION
Related to https://github.com/3scale-sre/platform/issues/1598

Closes https://issues.redhat.com/browse/SAAS3SCALE-70

We have reached really quick the max connections on `dev-eng-hcp-saas-int` environment.

By default, they are set to `151` which probably can be low on a dev environment:

```
show variables like 'max_connections';
+-----------------+-------+
| Variable_name   | Value |
+-----------------+-------+
| max_connections | 151   |
+-----------------+-------+
```

This PR doubles current max connections to `300`, I've checked in staging environment that max used connections is `164`, I would expect something similar here.

I preferred to the the change here (on the source), as it is totally harmless for any dev environment and avoid complex kustomization on `dev-eng-hcp-saas-int` environment (we have already tweak some other generic configs that have been spotted on`dev-eng-hcp-saas-int`).

/kind feature
/priority important-soon
/assign